### PR TITLE
Update bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bullseye-slim
 
-ADD feed-dl /bin/feed-dl
+ADD feed-dl /usr/bin/feed-dl
 
 RUN apt-get update && apt-get -y upgrade && \
     apt-get -y install procps librtlsdr0 librtlsdr-dev wget unzip build-essential pkg-config ca-certificates && \
@@ -9,11 +9,11 @@ RUN apt-get update && apt-get -y upgrade && \
     rm master.zip && \
     cd dump1090-master && \
     make && \
-    cp -a dump1090 view1090 public_html /bin && \
+    cp -a dump1090 view1090 public_html /usr/bin && \
     cd / && \
     rm -r /dump1090-master && \
-    '.' '/bin/feed-dl' && \
-     rm /bin/feed-dl && \
+    '.' '/usr/bin/feed-dl' && \
+    rm /usr/bin/feed-dl && \
     apt-get -y purge librtlsdr-dev wget unzip build-essential pkg-config && \
     apt-get --purge -y autoremove && \
     apt-get clean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM debian:stretch-slim
+FROM debian:bullseye-slim
 
 ADD feed-dl /bin/feed-dl
 
 RUN apt-get update && apt-get -y upgrade && \
     apt-get -y install procps librtlsdr0 librtlsdr-dev wget unzip build-essential pkg-config ca-certificates && \
-    wget https://github.com/MalcolmRobb/dump1090/archive/master.zip && \
+    wget https://github.com/Liggy/dump1090/archive/master.zip && \
     unzip master.zip && \
     rm master.zip && \
     cd dump1090-master && \

--- a/fr24feed.ini
+++ b/fr24feed.ini
@@ -1,5 +1,5 @@
 receiver="dvbt-mr"
-path="/bin/dump1090"
+path="/usr/bin/dump1090"
 bs="yes"
 raw="yes"
 logmode="2"


### PR DESCRIPTION
Update to Debian Bullseye, using own dump1090 repo including some small fixes.
Move executables from /bin to /usr/bin